### PR TITLE
Update GCP-VPC-Flow-logs-for-the-subnet-is-set-to-Off.json

### DIFF
--- a/policies/GCP-VPC-Flow-logs-for-the-subnet-is-set-to-Off.json
+++ b/policies/GCP-VPC-Flow-logs-for-the-subnet-is-set-to-Off.json
@@ -7,7 +7,7 @@
   "name": "GCP VPC Flow logs for the subnet is set to Off",
   "description": "This policy identifies the subnets in VPC Network which have Flow logs disabled. Flow logs enable the capturing of information about the IP traffic going to and from network interfaces in VPC Subnets.  It is recommended to enable the flow logs which can be used for network monitoring, forensics, real-time security analysis.",
   "rule.criteria": "4e0039a6-ead7-4a28-8041-ef4889c312df",
-  "searchModel.query": "config from cloud.resource where cloud.type = 'gcp' AND api.name = 'gcloud-compute-networks-subnets-list' AND json.rule = purpose does not contain INTERNAL_HTTPS_LOAD_BALANCER and purpose does not contain REGIONAL_MANAGED_PROXY and (enableFlowLogs is false or enableFlowLogs does not exist)",
+  "searchModel.query": "config from cloud.resource where cloud.type = 'gcp' AND api.name = 'gcloud-compute-networks-subnets-list' AND json.rule = purpose does not contain INTERNAL_HTTPS_LOAD_BALANCER and purpose does not contain REGIONAL_MANAGED_PROXY and purpose does not contain GLOBAL_MANAGED_PROXY and (enableFlowLogs is false or enableFlowLogs does not exist)",
   "recommendation": "1. Login to GCP Portal\n2. Goto VPC Network (on Left Panel)\n3. Select the reported VPC network and then click on the alerted subnet \n4. On 'Subnet details' page, click on 'EDIT'\n5. Set 'Flow Logs' to value 'On'\n6. Click on 'SAVE'.",
   "remediable": true,
   "remediation.cliScriptTemplate": "gcloud compute networks subnets update ${resourceName} --project=${account} --region ${region} --enable-flow-logs",


### PR DESCRIPTION
Per KeyBank:

Justification:

Google documentation states that flow logging is not supported for GLOBAL_MANAGED_PROXY also.

Per Google documentation (Terraform Registry ):

Flow logging isn't supported if the subnet purpose field is set to subnetwork is REGIONAL_MANAGED_PROXY or GLOBAL_MANAGED_PROXY

Note that INTERNAL_LOAD_BALANCER is fine to keep in the RQL for backward compatibility, but it is no longer a valid value and was changed to REGIONAL_MANAGED_PROXY. See https://cloud.google.com/load-balancing/docs/proxy-only-subnets#migrate-purpose

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
